### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var tree = require('flat-tree')
 var list = []
 
 var i = tree.index(0, 0) // get array index for depth: 0, offset: 0
-var j = tree.index(1, 0) // get array index for depth: 1, offset: 0
+var j = tree.index(0, 1) // get array index for depth: 0, offset: 1
 
 // use these indexes to store some data
 


### PR DESCRIPTION
I think the depth and offset are backwards in the README.

If run as-is, the indexes are wrong and even collids.