### PR TITLE
add children(9) test

### DIFF
--- a/test.js
+++ b/test.js
@@ -24,6 +24,7 @@ tape('children', function (t) {
   t.same(feed.children(0), null)
   t.same(feed.children(1), [0, 2])
   t.same(feed.children(3), [1, 5])
+  t.same(feed.children(9), [8, 10])
   t.end()
 })
 


### PR DESCRIPTION
Found out that the [rust implementation](https://github.com/mafintosh/flat-tree-rs/issues/3) isn't returning the right value for this entry. Figured we might add a regression test to this repo as a reference for future implementations. Thanks!

### refs
- https://github.com/mafintosh/flat-tree-rs/issues/3